### PR TITLE
change GitHub slug

### DIFF
--- a/_data/tutorialSeries.yml
+++ b/_data/tutorialSeries.yml
@@ -56,7 +56,7 @@
   HDF5 files in R. We also cover extracting and plotting data from HDF5 files." 
   lastModified:  2016-12-15 
   
-- slug: GitHub
+- slug: git-github
   name: Version Control with GitHub
   description: "This series teaches why version control is important and how to 
   use a common version control tool, GitHub. GitHub also allows for collaboration

--- a/_posts/data-institutes/git-intro/01-01-2016-git01.md
+++ b/_posts/data-institutes/git-intro/01-01-2016-git01.md
@@ -12,8 +12,8 @@ authors:
 contributors:
 categories: [self-paced-tutorial]
 tags: [git]
-mainTag: GitHub
-tutorialSeries: [GitHub]
+mainTag: git-github
+tutorialSeries: [git-github]
 code1:
 image:
  feature: codingInformatics.png

--- a/_posts/data-institutes/git-intro/01-01-2016-git02.md
+++ b/_posts/data-institutes/git-intro/01-01-2016-git02.md
@@ -12,8 +12,8 @@ authors:
 contributors:
 categories: [self-paced-tutorial]
 tags: [git]
-mainTag: GitHub
-tutorialSeries: [GitHub]
+mainTag: git-github
+tutorialSeries: [git-github]
 code1:
 image:
  feature: codingInformatics.png

--- a/_posts/data-institutes/git-intro/01-01-2016-git03.md
+++ b/_posts/data-institutes/git-intro/01-01-2016-git03.md
@@ -12,8 +12,8 @@ authors:
 contributors:
 categories: [self-paced-tutorial]
 tags: [git]
-mainTag: GitHub
-tutorialSeries: [GitHub]
+mainTag: git-github
+tutorialSeries: [git-github]
 code1:
 image:
  feature: codingInformatics.png

--- a/_posts/data-institutes/git-intro/01-01-2016-git04.md
+++ b/_posts/data-institutes/git-intro/01-01-2016-git04.md
@@ -12,8 +12,8 @@ authors:
 contributors:
 categories: [self-paced-tutorial]
 tags: [git]
-mainTag: GitHub
-tutorialSeries: [GitHub]
+mainTag: git-github
+tutorialSeries: [git-github]
 code1:
 image:
  feature: codingInformatics.png

--- a/_posts/data-institutes/git-intro/01-01-2016-git05.md
+++ b/_posts/data-institutes/git-intro/01-01-2016-git05.md
@@ -13,8 +13,8 @@ authors:
 contributors:
 categories: [self-paced-tutorial]
 tags: [git]
-mainTag: GitHub
-tutorialSeries: [GitHub]
+mainTag: git-github
+tutorialSeries: [git-github]
 code1:
 image:
  feature: codingInformatics.png

--- a/_posts/data-institutes/git-intro/01-01-2016-git06.md
+++ b/_posts/data-institutes/git-intro/01-01-2016-git06.md
@@ -12,8 +12,8 @@ authors:
 contributors:
 categories: [self-paced-tutorial]
 tags: [git]
-mainTag: GitHub
-tutorialSeries: [GitHub]
+mainTag: git-github
+tutorialSeries: [git-github]
 code1:
 image:
  feature: codingInformatics.png

--- a/org/tutorialSeries/git-github.md
+++ b/org/tutorialSeries/git-github.md
@@ -2,8 +2,8 @@
 layout: tutorial-series-landing
 title: 'Version Control with GitHub'
 categories: [tutorial-series]
-tutorialSeriesName: GitHub
-permalink: tutorial-series/GitHub/
+tutorialSeriesName: git-github
+permalink: tutorial-series/git-github/
 image:
   feature: codingInformatics.png
   credit: National Ecological Observatory Network


### PR DESCRIPTION
Perhaps GitHub can't be used as a slug or part of URL on the site?  Changing to git-github.  URLs to the series will need to be changed if this does work & fix the tutorials showing up on the series landing page. 