### PR TITLE
update vocabulary tables

### DIFF
--- a/processing_code/_data/languageTools.yml
+++ b/processing_code/_data/languageTools.yml
@@ -1,0 +1,11 @@
+- slug: git
+  name: Git & GitHub
+
+- slug: python
+  name: Python programming
+  
+- slug: R
+  name: R programming
+
+- slug: spreadsheet
+  name: Spreadsheets

--- a/processing_code/_data/tags.yml
+++ b/processing_code/_data/tags.yml
@@ -1,17 +1,17 @@
 - slug: data-viz
   name: Data Visualization 
 
-- slug: git
-  name: Git & GitHub
+- slug: data-analysis
+  name: Data Analysis 
+
+- slug: data-management
+  name: Data Management
 
 - slug: HDF5
   name: Hierarchical Data Formats (HDF5)
 
 - slug: hyperspectral-remote-sensing
   name: Hyperspectral Remote Sensing  
-
-- slug: informatics
-  name: Informatics
 
 - slug: lidar
   name: LiDAR
@@ -21,12 +21,6 @@
 
 - slug: phenology
   name: Phenology
-
-- slug: python
-  name: Python programming
-  
-- slug: R
-  name: R programming
 
 - slug: raster
   name: Raster Data  
@@ -42,4 +36,10 @@
   
 - slug: vector-data
   name: Vector Data 
+
+- slug: organisms
+  name: Organisimal Data
+  
+- slug: meteorology
+  name: Meteorology
 


### PR DESCRIPTION
RE conversation with Peter today.  
It is currently unclear if we will continue to use these tables, or just go directly from the tutorials to the Drupal vocabulary.  However, to help make the decision, I've updated tags (analogous to topics) to the currently used vocabulary.  I've also created a table to match the languagesTool section of the header -- this may never be used, however, it is there if needed.  They can all be deleted later.  