### PR TITLE
Add file path to code1

### DIFF
--- a/tutorials/R/NEON-API/NEON-API-How-To.Rmd
+++ b/tutorials/R/NEON-API/NEON-API-How-To.Rmd
@@ -10,7 +10,7 @@ packagesLibraries: httr, jsonlite, devtools, geoNEON, neonDataStackR
 topics: data-management, rep-sci
 languagesTool: R, API
 dataProduct:
-code1: NEON-API-How-To
+code1: R/NEON-API/NEON-API-How-To
 tutorialSeries: 
 urlTitle: neon-api-usage
 ---

--- a/tutorials/R/NEON-API/NEON-API-How-To.md
+++ b/tutorials/R/NEON-API/NEON-API-How-To.md
@@ -10,7 +10,7 @@ packagesLibraries: httr, jsonlite, devtools, geoNEON, neonDataStackR
 topics: data-management, rep-sci
 languagesTool: R, API
 dataProduct:
-code1: NEON-API-How-To
+code1: R/NEON-API/NEON-API-How-To
 tutorialSeries: 
 urlTitle: neon-api-usage
 ---

--- a/tutorials/R/NEON-pheno-temp-timeseries/01-explore-phenology-data.Rmd
+++ b/tutorials/R/NEON-pheno-temp-timeseries/01-explore-phenology-data.Rmd
@@ -10,7 +10,7 @@ packagesLibraries: dplyr, ggplot2
 topics: time-series, phenology, organisms
 languagesTool: R
 dataProduct: NEON.DP1.10055
-code1: 01-explore-phenology-data.R
+code1: R/NEON-pheno-temp-timeseries/01-explore-phenology-data.R
 tutorialSeries: neon-pheno-temp-series
 urlTitle: neon-plant-pheno-data-r
 ---

--- a/tutorials/R/NEON-pheno-temp-timeseries/01-explore-phenology-data.md
+++ b/tutorials/R/NEON-pheno-temp-timeseries/01-explore-phenology-data.md
@@ -10,7 +10,7 @@ packagesLibraries: dplyr, ggplot2
 topics: time-series, phenology, organisms
 languagesTool: R
 dataProduct: NEON.DP1.10055
-code1: 01-explore-phenology-data.R
+code1: R/NEON-pheno-temp-timeseries/01-explore-phenology-data.R
 tutorialSeries: neon-pheno-temp-series
 urlTitle: neon-plant-pheno-data-r
 ---

--- a/tutorials/R/NEON-pheno-temp-timeseries/02-drivers-pheno-change-temp.Rmd
+++ b/tutorials/R/NEON-pheno-temp-timeseries/02-drivers-pheno-change-temp.Rmd
@@ -10,7 +10,7 @@ packagesLibraries: dplyr, ggplot2, lubridate
 topics: time-series, meteorology
 languagesTool: R
 dataProduct: NEON.DP1.00002, NEON.DP1.00003
-code1: 02-drivers-pheno-change-temp.R
+code1: R/NEON-pheno-temp-timeseries/02-drivers-pheno-change-temp.R
 tutorialSeries: neon-pheno-temp-series
 urlTitle: neon-SAAT-temp-r
 

--- a/tutorials/R/NEON-pheno-temp-timeseries/02-drivers-pheno-change-temp.md
+++ b/tutorials/R/NEON-pheno-temp-timeseries/02-drivers-pheno-change-temp.md
@@ -10,7 +10,7 @@ packagesLibraries: dplyr, ggplot2, lubridate
 topics: time-series, meteorology
 languagesTool: R
 dataProduct: NEON.DP1.00002, NEON.DP1.00003
-code1: 02-drivers-pheno-change-temp.R
+code1: R/NEON-pheno-temp-timeseries/02-drivers-pheno-change-temp.R
 tutorialSeries: neon-pheno-temp-series
 urlTitle: neon-SAAT-temp-r
 

--- a/tutorials/R/NEON-pheno-temp-timeseries/03-plot-discrete-continuous-data-pheno-temp.Rmd
+++ b/tutorials/R/NEON-pheno-temp-timeseries/03-plot-discrete-continuous-data-pheno-temp.Rmd
@@ -10,7 +10,7 @@ packagesLibraries: dplyr, ggplot2, lubridate
 topics: timeseries, meteorology, phenology, organisms
 languagesTool: R
 dataProduct: NEON.DP1.10055, 
-code1: 03-plot-discrete-continuous-data-pheno-temp.R
+code1: R/NEON-pheno-temp-timeseries/03-plot-discrete-continuous-data-pheno-temp.R
 tutorialSeries:  neon-pheno-temp-series
 urlTitle: neon-pheno-temp-plots-r
 ---

--- a/tutorials/R/NEON-pheno-temp-timeseries/03-plot-discrete-continuous-data-pheno-temp.Rmd
+++ b/tutorials/R/NEON-pheno-temp-timeseries/03-plot-discrete-continuous-data-pheno-temp.Rmd
@@ -1,8 +1,7 @@
 ---
 syncID: 03868e86e4d34d1fa88caacaddf95a57
 title: "Plot Continuous & Discrete Data Together"
-description: "This tutorial discusses ways to plot plant phenology (discrete time
-series) and single-aspirated temperature (continuous time series) together."
+description: "This tutorial discusses ways to plot plant phenology (discrete time series) and single-aspirated temperature (continuous time series) together."
 dateCreated: 2017-08-01
 authors: Lee Stanish, Megan A. Jones, Natalie Robinson
 contributors: Katie Jones, Cody Flagg

--- a/tutorials/R/NEON-pheno-temp-timeseries/03-plot-discrete-continuous-data-pheno-temp.md
+++ b/tutorials/R/NEON-pheno-temp-timeseries/03-plot-discrete-continuous-data-pheno-temp.md
@@ -10,7 +10,7 @@ packagesLibraries: dplyr, ggplot2, lubridate
 topics: timeseries, meteorology, phenology, organisms
 languagesTool: R
 dataProduct: NEON.DP1.10055, 
-code1: 03-plot-discrete-continuous-data-pheno-temp.R
+code1: R/NEON-pheno-temp-timeseries/03-plot-discrete-continuous-data-pheno-temp.R
 tutorialSeries:  neon-pheno-temp-series
 urlTitle: neon-pheno-temp-plots-r
 ---

--- a/tutorials/R/NEON-pheno-temp-timeseries/03-plot-discrete-continuous-data-pheno-temp.md
+++ b/tutorials/R/NEON-pheno-temp-timeseries/03-plot-discrete-continuous-data-pheno-temp.md
@@ -1,8 +1,7 @@
 ---
 syncID: 03868e86e4d34d1fa88caacaddf95a57
 title: "Plot Continuous & Discrete Data Together"
-description: "This tutorial discusses ways to plot plant phenology (discrete time
-series) and single-aspirated temperature (continuous time series) together."
+description: "This tutorial discusses ways to plot plant phenology (discrete time series) and single-aspirated temperature (continuous time series) together."
 dateCreated: 2017-08-01
 authors: Lee Stanish, Megan A. Jones, Natalie Robinson
 contributors: Katie Jones, Cody Flagg

--- a/tutorials/R/R-nonSeries-lessons/R-dplyr-GREPL-Summarise-Piping.Rmd
+++ b/tutorials/R/R-nonSeries-lessons/R-dplyr-GREPL-Summarise-Piping.Rmd
@@ -10,7 +10,7 @@ packagesLibraries: dplyr
 topics: data-analysis
 languagesTool: R
 dataProduct: 
-code1: R-dplyr-GREPL-Summarise-Piping.R
+code1: R/R-nonSeries-lessons/R-dplyr-GREPL-Summarise-Piping.R
 tutorialSeries: 
 urlTitle: grepl-filter-piping-dplyr-r
 ---

--- a/tutorials/R/R-nonSeries-lessons/R-dplyr-GREPL-Summarise-Piping.md
+++ b/tutorials/R/R-nonSeries-lessons/R-dplyr-GREPL-Summarise-Piping.md
@@ -10,7 +10,7 @@ packagesLibraries: dplyr
 topics: data-analysis
 languagesTool: R
 dataProduct: 
-code1: R-dplyr-GREPL-Summarise-Piping.R
+code1: R/R-nonSeries-lessons/R-dplyr-GREPL-Summarise-Piping.R
 tutorialSeries: 
 urlTitle: grepl-filter-piping-dplyr-r
 

--- a/tutorials/R/dc-spatial-vector/00-open-a-shapefile.md
+++ b/tutorials/R/dc-spatial-vector/00-open-a-shapefile.md
@@ -10,7 +10,7 @@ packagesLibraries: rgdal, raster
 topics: vector-data, spatial-data-gis
 languagesTool:
 dataProduct:
-code1: /R/dc-spatial-vector/00-open-a-shapefile.R
+code1: R/dc-spatial-vector/00-open-a-shapefile.R
 tutorialSeries: vector-data-series
 urlTitle: dc-open-shapefiles-r
 

--- a/tutorials/R/neonUtilities/neonDataStackR.Rmd
+++ b/tutorials/R/neonUtilities/neonDataStackR.Rmd
@@ -9,7 +9,7 @@ estimatedTime: 5 minutes
 packagesLibraries: neonDataStackR
 topics: data-management, rep-sci
 languageTool: R
-code1: neonDataStackR.R
+code1: R/neonUtilities/neonDataStackR.R
 tutorialSeries:
 urlTitle: neonDataStackR
 

--- a/tutorials/R/neonUtilities/neonDataStackR.md
+++ b/tutorials/R/neonUtilities/neonDataStackR.md
@@ -9,7 +9,7 @@ estimatedTime: 5 minutes
 packagesLibraries: neonDataStackR
 topics: data-management, rep-sci
 languageTool: R
-code1: neonDataStackR.R
+code1: R/neonUtilities/neonDataStackR.R
 tutorialSeries:
 urlTitle: neonDataStackR
 

--- a/tutorials/dataviz/DataVis-plotly-R.Rmd
+++ b/tutorials/dataviz/DataVis-plotly-R.Rmd
@@ -10,7 +10,7 @@ packagesLibraries: ggplot, plotly
 topics: data-viz
 languagesTool: R
 dataProduct:
-code1: /dataviz/DataVis-plotly-R.R
+code1: dataviz/DataVis-plotly-R.R
 tutorialSeries:
 urlTitle: plotly
 ---

--- a/tutorials/dataviz/DataVis-plotly-R.md
+++ b/tutorials/dataviz/DataVis-plotly-R.md
@@ -10,7 +10,7 @@ packagesLibraries: ggplot, plotly
 topics: data-viz
 languagesTool: R
 dataProduct:
-code1: /dataviz/DataVis-plotly-R.R
+code1: dataviz/DataVis-plotly-R.R
 tutorialSeries:
 urlTitle: plotly-r
 ---

--- a/tutorials/lidar/Create-Lidar-CHM-R.Rmd
+++ b/tutorials/lidar/Create-Lidar-CHM-R.Rmd
@@ -10,7 +10,7 @@ packagesLibraries: raster, rgdal
 topics: lidar, R, raster, remote-sensing, spatial-data-gis
 languagesTool: R
 dataProduct:
-code1:
+code1: lidar/Create-Lidar-CHM-R.R
 tutorialSeries: [intro-lidar-r-series]
 urlTitle: create-chm-rasters-r
 ---

--- a/tutorials/lidar/Create-Lidar-CHM-R.md
+++ b/tutorials/lidar/Create-Lidar-CHM-R.md
@@ -10,8 +10,8 @@ packagesLibraries: raster, rgdal
 topics: lidar, R, raster, remote-sensing, spatial-data-gis
 languagesTool: R
 dataProduct:
-code1:
-tutorialSeries: [intro-lidar-r-series]
+code1: lidar/Create-Lidar-CHM-R.R
+tutorialSeries: intro-lidar-r-series
 urlTitle: create-chm-rasters-r
 ---
 

--- a/tutorials/lidar/extract-raster-data-R.Rmd
+++ b/tutorials/lidar/extract-raster-data-R.Rmd
@@ -10,7 +10,7 @@ packagesLibraries: raster, sp, rgdal, maptools, rgeos, dplyr, ggplot
 topics: lidar, R, raster, remote-sensing, spatial-data-gis
 languagesTool:
 dataProduct:
-code1: /LIDAR/extract-raster-data-R.R
+code1: lidar/extract-raster-data-R.R
 tutorialSeries: intro-lidar-r-series
 urlTitle: extract-values-rasters-r
 ---

--- a/tutorials/lidar/extract-raster-data-R.md
+++ b/tutorials/lidar/extract-raster-data-R.md
@@ -10,7 +10,7 @@ packagesLibraries: raster, sp, rgdal, maptools, rgeos, dplyr, ggplot
 topics: lidar, R, raster, remote-sensing, spatial-data-gis
 languagesTool:
 dataProduct:
-code1: /LIDAR/extract-raster-data-R.R
+code1: lidar/extract-raster-data-R.R
 tutorialSeries: intro-lidar-r-series
 urlTitle: extract-values-rasters-r
 ---

--- a/tutorials/teaching-modules/disturb-events-co13/COOP-NEIS-Precipitation-In-R.Rmd
+++ b/tutorials/teaching-modules/disturb-events-co13/COOP-NEIS-Precipitation-In-R.Rmd
@@ -10,7 +10,7 @@ packagesLibraries: ggplot2, plotly
 topics: time-series, meteorology, data-viz
 languagesTool: R
 dataProduct:
-code1: /teaching-modules/disturb-events-co13/COOP-NEIS-Precipitation-In-R.R	
+code1: teaching-modules/disturb-events-co13/COOP-NEIS-Precipitation-In-R.R	
 tutorialSeries:
 urlTitle: da-viz-coop-precip-data-R
 ---

--- a/tutorials/teaching-modules/disturb-events-co13/COOP-NEIS-Precipitation-In-R.md
+++ b/tutorials/teaching-modules/disturb-events-co13/COOP-NEIS-Precipitation-In-R.md
@@ -10,7 +10,7 @@ packagesLibraries: ggplot2, plotly
 topics: time-series, meteorology, data-viz
 languagesTool: R
 dataProduct:
-code1: /teaching-modules/disturb-events-co13/COOP-NEIS-Precipitation-In-R.R	
+code1: teaching-modules/disturb-events-co13/COOP-NEIS-Precipitation-In-R.R	
 tutorialSeries:
 urlTitle: da-viz-coop-precip-data-R
 ---

--- a/tutorials/teaching-modules/disturb-events-co13/Disturb-Event-Detailed-Lesson.Rmd
+++ b/tutorials/teaching-modules/disturb-events-co13/Disturb-Event-Detailed-Lesson.Rmd
@@ -10,6 +10,7 @@ packagesLibraries: ggplot2, plotly
 topics: time-series, meteorology, data-viz
 languagesTool: spreadsheet, R, plotly
 dataProduct: DP3.30024.001
+code1: 
 tutorialSeries: disturb-events-co13
 urlTitle: tm-disturbance-events-co13flood
 

--- a/tutorials/teaching-modules/disturb-events-co13/Disturb-Event-Detailed-Lesson.md
+++ b/tutorials/teaching-modules/disturb-events-co13/Disturb-Event-Detailed-Lesson.md
@@ -10,6 +10,7 @@ packagesLibraries: ggplot2, plotly
 topics: time-series, meteorology, data-viz
 languagesTool: spreadsheet, R, plotly
 dataProduct: DP3.30024.001
+code1: 
 tutorialSeries: disturb-events-co13
 urlTitle: tm-disturbance-events-co13flood
 

--- a/tutorials/teaching-modules/disturb-events-co13/NEON-Boulder-Flood-LiDAR-in-R.Rmd
+++ b/tutorials/teaching-modules/disturb-events-co13/NEON-Boulder-Flood-LiDAR-in-R.Rmd
@@ -10,7 +10,7 @@ packagesLibraries: rgdal, raster
 topics: time-series, meteorology, data-viz
 languagesTool: R
 dataProduct:
-code1: /teaching-modules/disturb-events-co13/NEON-Boulder-Flood-LiDAR-in-R.R	
+code1: teaching-modules/disturb-events-co13/NEON-Boulder-Flood-LiDAR-in-R.R	
 tutorialSeries:
 urlTitle: da-viz-neon-lidar-co13flood-R
 ---

--- a/tutorials/teaching-modules/disturb-events-co13/NEON-Boulder-Flood-LiDAR-in-R.md
+++ b/tutorials/teaching-modules/disturb-events-co13/NEON-Boulder-Flood-LiDAR-in-R.md
@@ -10,7 +10,7 @@ packagesLibraries: rgdal, raster
 topics: time-series, meteorology, data-viz
 languagesTool: R
 dataProduct:
-code1: /teaching-modules/disturb-events-co13/NEON-Boulder-Flood-LiDAR-in-R.R	
+code1: teaching-modules/disturb-events-co13/NEON-Boulder-Flood-LiDAR-in-R.R	
 tutorialSeries:
 urlTitle: da-viz-neon-lidar-co13flood-R
 ---

--- a/tutorials/teaching-modules/disturb-events-co13/USGS-Stream-Discharge-In-R.Rmd
+++ b/tutorials/teaching-modules/disturb-events-co13/USGS-Stream-Discharge-In-R.Rmd
@@ -10,7 +10,7 @@ packagesLibraries: ggplot2, plotly
 topics: time-series, meteorology, data-viz
 languagesTool: R
 dataProduct:
-code1: /teaching-modules/disturb-events-co13/USGS-Stream-Discharge-In-R.R	
+code1: teaching-modules/disturb-events-co13/USGS-Stream-Discharge-In-R.R	
 tutorialSeries: 
 urlTitle: da-viz-usgs-stream-discharge-data-R
 ---

--- a/tutorials/teaching-modules/disturb-events-co13/USGS-Stream-Discharge-In-R.md
+++ b/tutorials/teaching-modules/disturb-events-co13/USGS-Stream-Discharge-In-R.md
@@ -10,7 +10,7 @@ packagesLibraries: ggplot2, plotly
 topics: time-series, meteorology, data-viz
 languagesTool: R
 dataProduct:
-code1: /teaching-modules/disturb-events-co13/USGS-Stream-Discharge-In-R.R	
+code1: teaching-modules/disturb-events-co13/USGS-Stream-Discharge-In-R.R	
 tutorialSeries: 
 urlTitle: da-viz-usgs-stream-discharge-data-R
 ---

--- a/tutorials/teaching-modules/disturb-events-co13/nCLIMDIV-Palmer-Drought-In-R.Rmd
+++ b/tutorials/teaching-modules/disturb-events-co13/nCLIMDIV-Palmer-Drought-In-R.Rmd
@@ -10,7 +10,7 @@ packagesLibraries: ggplot2, plotly
 topics: time-series, meteorology, data-viz
 languagesTool: R
 dataProduct: 
-code1: /teaching-modules/disturb-events-co13/nCLIMDIV-Palmer-Drought-In-R.R
+code1: teaching-modules/disturb-events-co13/nCLIMDIV-Palmer-Drought-In-R.R
 tutorialSeries: 
 urlTitle: da-viz-nclimdiv-palmer-drought-data-r
 ---

--- a/tutorials/teaching-modules/disturb-events-co13/nCLIMDIV-Palmer-Drought-In-R.md
+++ b/tutorials/teaching-modules/disturb-events-co13/nCLIMDIV-Palmer-Drought-In-R.md
@@ -10,7 +10,7 @@ packagesLibraries: ggplot2, plotly
 topics: time-series, meteorology, data-viz
 languagesTool: R
 dataProduct: 
-code1: /teaching-modules/disturb-events-co13/nCLIMDIV-Palmer-Drought-In-R.R
+code1: teaching-modules/disturb-events-co13/nCLIMDIV-Palmer-Drought-In-R.R
 tutorialSeries: 
 urlTitle: da-viz-nclimdiv-palmer-drought-data-r
 ---

--- a/tutorials/znewtutorialForTest.md
+++ b/tutorials/znewtutorialForTest.md
@@ -12,7 +12,7 @@ languagesTool: R, python
 dataProduct: 
 code1: 
 tutorialSeries: 
-urlTitle: styles-css
+urlTitle: test-new-tutorial
 ---
 
 This page shows all the NEON stylings as currently shown on the


### PR DESCRIPTION
To correctly download code1 must have relative path from the code directory.  This corrects errors where only the code filename was used. 