### PR TITLE
change title from NEON Utilities to neonUtilities

### DIFF
--- a/code/Python/neonUtilities/neonUtilitiesPython.ipynb
+++ b/code/Python/neonUtilities/neonUtilitiesPython.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "---\n",
     "syncID: 5be9f80592394af3bc09cf8e469fef6e\n",
-    "title: \"Using NEON Utilities in Python\"\n",
+    "title: \"Using neonUtilities in Python\"\n",
     "description: \"Use the neonUtilities R package in Python, via the rpy2 library.\"\n",
     "dateCreated: 2018-5-10\n",
     "authors: Claire K. Lunch\n",

--- a/processing_code/TutorialUniqueIDRecord.csv
+++ b/processing_code/TutorialUniqueIDRecord.csv
@@ -127,7 +127,7 @@ bb90898de165446f9a0e92e1399f4697,Hyperspectral Variation Uncertainty Analysis in
 a6db1047adb34f41b9d17d6ed41f5fd5,Exploring Uncertainty in LiDAR Data,
 63993d7274f84e51a1047e1fea9aece1,Install & Set Up Docker For Use With eddy4R,
 93d1cc4e89d84ee09f1294e02ff2d440,Resources for Learning R,
-5be9f80592394af3bc09cf8e469fef6e,Using NEON Utilities in Python,
+5be9f80592394af3bc09cf8e469fef6e,Using neonUtilities in Python,
 67a5e95e1b7445aca7d7750b75c0ee98,,
 61ad1fc43ddd45b49cad1bca48656bbe,,
 046a83d83f2042d8b40dea1b20fd6779,,

--- a/tutorials/Python/neonUtilities/neonUtilitiesPython.md
+++ b/tutorials/Python/neonUtilities/neonUtilitiesPython.md
@@ -1,7 +1,6 @@
-
 ---
 syncID: 5be9f80592394af3bc09cf8e469fef6e
-title: "Using NEON Utilities in Python"
+title: "Using neonUtilities in Python"
 description: "Use the neonUtilities R package in Python, via the rpy2 library."
 dateCreated: 2018-5-10
 authors: Claire K. Lunch

--- a/tutorials/R/eddy4r/dockerEddy4r.Rmd
+++ b/tutorials/R/eddy4r/dockerEddy4r.Rmd
@@ -38,16 +38,14 @@ The directions on how to install docker are heavily borrowed from the author's
 of CyVerse's Container Camp's 
 <a href="https://cyverse-container-camp-workshop-2018.readthedocs-hosted.com/en/latest/docker/dockerintro.html" target="_blank"> Intro to Docker</a> and we thank them for providing the information. 
 
-The directions for how to access eddy4R comes from Metzger, S., D. Durden, C. Sturtevant, H. Luo, N. Pingintha-durden, and T. Sachs (2017). eddy4R 0.2.0: a DevOps model for community-extensible processing and analysis of eddy-covariance data based on R, Git, Docker, and HDF5. Geoscientific Model Development 10:3189–3206. doi: 
+The directions for how to access eddy4R comes from 
+
+Metzger, S., D. Durden, C. Sturtevant, H. Luo, N. Pingintha-durden, and T. Sachs (2017). eddy4R 0.2.0: a DevOps model for community-extensible processing and analysis of eddy-covariance data based on R, Git, Docker, and HDF5. Geoscientific Model Development 10:3189–3206. doi: 
 <a href="https://www.geosci-model-dev.net/10/3189/2017/" target="_blank">10.5194/gmd-10-3189-2017</a>. 
 
 </div>
 
 
-## Why Docker? 
-[MJ: This section still needs to be completed.]
-
-"Getting all the tooling setup on your computer can be a daunting task, but not with Docker." 
 
 In the tutorial below, we give the very barest of information to get Docker set
 up for use with the NEON R package eddy4R. For more information on using Docker, 

--- a/tutorials/R/eddy4r/dockerEddy4r.md
+++ b/tutorials/R/eddy4r/dockerEddy4r.md
@@ -38,16 +38,13 @@ The directions on how to install docker are heavily borrowed from the author's
 of CyVerse's Container Camp's 
 <a href="https://cyverse-container-camp-workshop-2018.readthedocs-hosted.com/en/latest/docker/dockerintro.html" target="_blank"> Intro to Docker</a> and we thank them for providing the information. 
 
-The directions for how to access eddy4R comes from Metzger, S., D. Durden, C. Sturtevant, H. Luo, N. Pingintha-durden, and T. Sachs (2017). eddy4R 0.2.0: a DevOps model for community-extensible processing and analysis of eddy-covariance data based on R, Git, Docker, and HDF5. Geoscientific Model Development 10:3189–3206. doi: 
+The directions for how to access eddy4R comes from 
+
+Metzger, S., D. Durden, C. Sturtevant, H. Luo, N. Pingintha-durden, and T. Sachs (2017). eddy4R 0.2.0: a DevOps model for community-extensible processing and analysis of eddy-covariance data based on R, Git, Docker, and HDF5. Geoscientific Model Development 10:3189–3206. doi: 
 <a href="https://www.geosci-model-dev.net/10/3189/2017/" target="_blank">10.5194/gmd-10-3189-2017</a>. 
 
 </div>
 
-
-## Why Docker? 
-[MJ: This section still needs to be completed.]
-
-"Getting all the tooling setup on your computer can be a daunting task, but not with Docker." 
 
 In the tutorial below, we give the very barest of information to get Docker set
 up for use with the NEON R package eddy4R. For more information on using Docker, 


### PR DESCRIPTION
@cklunch I changed the title from "Using NEON Utilities in Python" to "Using neonUtilities in Python" as the tutorial wasn't coming up in the search for "neonUtilities" which I think is important.  
Let me know if you disagree and I'll revert.  For now I'll merge as it will be a few days before you get this. 