### PR TITLE
remove version #s

### DIFF
--- a/processing_code/_includes/wkSetup/_setup_R_Rstudio.html
+++ b/processing_code/_includes/wkSetup/_setup_R_Rstudio.html
@@ -5,7 +5,7 @@
 *  <a href="http://cran.r-project.org/bin/windows/base/release.htm" target="_blank">Download R for Windows here</a>
 * Run the .exe file that was just downloaded
 * <a href="http://www.rstudio.com/ide/download/desktop" target="_blank">Go to the RStudio Download page</a>
-* Under <i>Installers</i> select <b>RStudio 0.98.1103 - Windows XP/Vista/7/8</b>
+* Under <i>Installers</i> select <b>RStudio X.XX.XXX - Windows Vista/7/8/10</b>
 * Double click the file to install it
 
 
@@ -19,7 +19,7 @@ R for (Mac) OS X</i>
 will download.
 * Double click on the file that was downloaded and R will install
 * Go to the <a href="http://www.rstudio.com/ide/download/desktop" target="_blank">RStudio Download page</a>
-* Under <i>Installers</i> select <b>RStudio 0.98.1103 - Mac OS X 10.6+ (64-bit)</b> to download it.
+* Under <i>Installers</i> select <b>RStudio 0.98.1103 - Mac OS X XX.X (64-bit)</b> to download it.
 * Once it's downloaded, double click the file to install it
 
 Once R and RStudio are installed, click to open RStudio. If you don't get any error messages you are set.  If there is an error message, you will need to re-install the program. 


### PR DESCRIPTION
R setup instructions no longer include the specific version # so that there isn't confusion when new versions are released. 