### PR TITLE
02-spatial-data-formats: removed weird {:.notice}

### DIFF
--- a/old-tutorials-in-development/tutorials-in-development/R/dc-spatio-temporal-intro/02-spatial-data-formats.Rmd
+++ b/old-tutorials-in-development/tutorials-in-development/R/dc-spatio-temporal-intro/02-spatial-data-formats.Rmd
@@ -176,7 +176,7 @@ include:
 
 <i class="fa fa-star"></i> **Data Tip:** A shapefile will only contain **one
 type of vector data**: points, lines or polygons.
-{: .notice}
+
 
 ```{r import-vector, warning=FALSE}
 
@@ -409,7 +409,6 @@ within a `tif` or `GeoTIFF` file are also what your camera uses to store
 information about how and when a picture was taken! And how your computer reads
 this metadata and identifies, for example, the make and model of the camera or
 the date the photo was taken.
-{: .notice}
 
 ### Other Raster File Formats
 

--- a/old-tutorials-in-development/tutorials-in-development/R/dc-spatio-temporal-intro/04-intro-CRS-projection.Rmd
+++ b/old-tutorials-in-development/tutorials-in-development/R/dc-spatio-temporal-intro/04-intro-CRS-projection.Rmd
@@ -1,17 +1,17 @@
 ---
 title: "Spatial Intro 04 Intro to Coordinate Reference Systems & Spatial Projections"
 code1: null
-contributors: null
-dataProduct: null
-dateCreated: '2020-05-26'
 description: This lesson covers the key spatial attributes that are needed to work
   and spatial resolution with spatial data including Coordinate Reference Systems
   (CRS), Extent
+dateCreated: '2020-05-26'
+authors: Leah A. Wasser, Megan A. Jones
+contributors: Alison Dernbach
+dataProduct: null
 estimatedTime: 1 hour
 languagesTool: R
 packagesLibraries: rgdal, ggplot2, rgeos, raster
 syncID: null
-authors: Leah A. Wasser, Megan A. Jones, Alison Dernbach
 topics: spatial-data-gis
 tutorialSeries: spatial-data-management-series
 urlTitle: null


### PR DESCRIPTION
Hey @donal-at-NEON, just a quick edit to delete the {:.notice} a couple of times in this tutorial. All the other tutorials I've completed don't have this and moving forward I'll delete it whenever I see it. Thanks!